### PR TITLE
Update utils.py

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,3 +1,4 @@
+import sys
 import getopt
 import os, json, re
 from solidity_parser import parser


### PR DESCRIPTION
Fixed "NameError: name 'sys' is not defined" in Python>=3.11